### PR TITLE
Fix documentation

### DIFF
--- a/include/weak_forms/residual_functor.h
+++ b/include/weak_forms/residual_functor.h
@@ -179,13 +179,13 @@ namespace WeakForms
    * // of its components.
    * const FieldSolution<dim> solution;
    * const SubSpaceExtractors::Vector subspace_extractor_v(0, "v",
-   * "\\mathbf{v}"); const SubSpaceExtractors::Scalar
-   * subspace_extractor_s(spacedim, "s", "s");
+   *   "\\mathbf{v}"); 
+   * const SubSpaceExtractors::Scalar subspace_extractor_s(spacedim, "s", "s");
    *
    * // Extract subspace of field solution; namely operators that
    * // represent a vector field gradient and a scalar field value.
-   * const auto soln_v_grad = solution[subspace_extractor].gradient();
-   * const auto soln_s_val  = solution[subspace_extractor].value();
+   * const auto soln_v_grad = solution[subspace_extractor_v].gradient();
+   * const auto soln_s_val  = solution[subspace_extractor_s].value();
    *
    * // Define test functions for the various components of the problem.
    * const TestFunction<dim, spacedim> test;
@@ -216,7 +216,7 @@ namespace WeakForms
    * using ADNumber_t =
    *   typename decltype(residual_ss_v)::template ad_type<double, ad_typecode>;
    *
-   * // Now create a specific instance of an residual view functor: this not
+   * // Now create a specific instance of a residual view functor: this not
    * // only provides the definition of the residual component to be considered,
    * // but also a means to differentiate it with respect to its arguments.
    * // This is achieved with a call to ResidualViewFunctor::value(), with the
@@ -249,7 +249,7 @@ namespace WeakForms
    *      const dealii::Tensor<2, dim, ADNumber_t> &grad_v,
    *      const ADNumber_t &                        s)
    * {
-   *   const Tensor<2, dim, ADNumber_t> res_grad_v = ...;
+   *   const dealii::Tensor<2, dim, ADNumber_t> res_grad_v = ...;
    *   return res_grad_v;
    * });
    * const auto residual_s


### PR DESCRIPTION
Just fix a few typos. I'll hijack this PR to ask a couple of questions:
 1.  [here](https://jppelteret.github.io/dealii-weak_forms/classWeakForms_1_1ResidualViewFunctor.html)  after the code, there is a formula that shows the residual view expressions. There is an extra derivative compared to what I would expect. The documentation says `The linear forms, which are the first two terms on the right of the equation,`. Why are they derivative there? Why isn't it simply `R`? Also what's `a`?
 2. I have been looking at tests as examples. [Here](https://github.com/jppelteret/dealii-weak_forms/blob/main/tests/weak_forms/step-6-variant_02-residual_view_ad_01.cc#L110-L112), the linear form is not put inside the residual term. Is it possible to put the source term in the residual or not? I understand that there is no point in putting that term in the residual. It just bothers me that the residual doesn't have the source even if it doesn't matter. Note that here, the result is exactly what I would expect, there is no extra derivative.